### PR TITLE
don't install setup.py as script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,4 @@ if __name__ == '__main__':
         license='MIT',
         classifiers=_classifiers,
         keywords=['testing', 'modules'],
-        scripts=['safer.py'],
     )


### PR DESCRIPTION
`setup.py` [claims](https://github.com/rec/safer/blob/85c53f9d0502a6a2410741b3b662ea8ad73cff2e/setup.py#L32) that `safer.py` is an (executable) script.

The [docs](https://docs.python.org/3/distutils/setupscript.html#installing-scripts) say that "Scripts are files containing Python source code, intended to be started from the command line." and should have something like `#! /usr/bin/env python` in their first line.

This is not the case for [safer.py](https://github.com/rec/safer/blob/85c53f9d0502a6a2410741b3b662ea8ad73cff2e/safer.py#L1) nor does this file contain any logic to be executed when called from the command line.

This change removes this entry.

fixes #16