### PR TITLE
Reduce use of tempfile (fix #25)

### DIFF
--- a/test/test_open.py
+++ b/test/test_open.py
@@ -102,15 +102,15 @@ class TestSafer(unittest.TestCase):
             fp.write('OK!')
             if uses_files:
                 after = set(os.listdir('.'))
-                assert len(before) + 2 == len(after)
-                assert len(after.difference(before)) == 2
+                assert len(before) + 1 == len(after)
+                assert len(after.difference(before)) == 1
 
         assert FILENAME.read_text() == 'OK!'
 
         if uses_files:
             after = set(os.listdir('.'))
-            assert len(before) + 1 == len(after)
-            assert len(after.difference(before)) == 1
+            assert len(before) == len(after)
+            assert len(after.difference(before)) == 0
 
     def test_error_with_copy(self, safer_open):
         FILENAME.write_text('hello')
@@ -214,3 +214,17 @@ class TestSafer(unittest.TestCase):
         with safer_open(FILENAME, 'wt') as fp:
             fp.write('goodbye')
         assert FILENAME.read_text() == 'goodbye'
+
+    def test_tempfile_perms(self, safer_open):
+        temp_files = False, True, 'three'
+        perms = []
+        for temp_file in temp_files:
+            filename = str(temp_file)
+            if isinstance(temp_file, str):
+                temp_file += '.tmpfile'
+            with safer_open(filename, 'w', temp_file=temp_file):
+                pass
+            perms.append(os.stat(filename).st_mode)
+
+        assert perms == [perms[0]] * len(perms)
+        assert perms[0] in (0o100644, 0o100664)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Reduce the use of temporary files by refining the logic for handling temporary file creation and permissions. Fix test assertions to accurately reflect the number of temporary files created. Add a test to ensure consistent permissions for temporary files.

Bug Fixes:
- Fix the logic in test assertions to correctly account for the number of temporary files created during tests.

Enhancements:
- Improve the handling of temporary file permissions by ensuring consistent permissions across different temporary file scenarios.

Tests:
- Add a new test to verify that temporary files have consistent permissions when created with different configurations.

<!-- Generated by sourcery-ai[bot]: end summary -->